### PR TITLE
fix: :bug: fixed the issue that parallel scanning cannot be performed…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/vue-table": "^8.21.3",
     "@tanstack/vue-virtual": "^3.13.10",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-log": "~2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@vueuse/core": "^13.3.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.5.0
+      '@tauri-apps/plugin-log':
+        specifier: ~2.6.0
+        version: 2.6.0
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.2.7
@@ -554,6 +557,9 @@ packages:
   '@tauri-apps/api@2.5.0':
     resolution: {integrity: sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==}
 
+  '@tauri-apps/api@2.7.0':
+    resolution: {integrity: sha512-v7fVE8jqBl8xJFOcBafDzXFc8FnicoH3j8o8DNNs0tHuEBmXUDqrCOAzMRX0UkfpwqZLqvrvK0GNQ45DfnoVDg==}
+
   '@tauri-apps/cli-darwin-arm64@2.5.0':
     resolution: {integrity: sha512-VuVAeTFq86dfpoBDNYAdtQVLbP0+2EKCHIIhkaxjeoPARR0sLpFHz2zs0PcFU76e+KAaxtEtAJAXGNUc8E1PzQ==}
     engines: {node: '>= 10'}
@@ -624,6 +630,9 @@ packages:
     resolution: {integrity: sha512-rAtHqG0Gh/IWLjN2zTf3nZqYqbo81oMbqop56rGTjrlWk9pTTAjkqOjSL9XQLIMZ3RbeVjveCqqCA0s8RnLdMg==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-log@2.6.0':
+    resolution: {integrity: sha512-gVp3l31akA1Jk2bZsTA0hMFD5/gLe49Nw1btu5lViau0QqgC2XyT79LSwvy7a44ewtQbSexchqIg7oTJKMIbXQ==}
 
   '@tauri-apps/plugin-opener@2.2.7':
     resolution: {integrity: sha512-uduEyvOdjpPOEeDRrhwlCspG/f9EQalHumWBtLBnp3fRp++fKGLqDOyUhSIn7PzX45b/rKep//ZQSAQoIxobLA==}
@@ -1514,6 +1523,8 @@ snapshots:
 
   '@tauri-apps/api@2.5.0': {}
 
+  '@tauri-apps/api@2.7.0': {}
+
   '@tauri-apps/cli-darwin-arm64@2.5.0':
     optional: true
 
@@ -1560,6 +1571,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.5.0
       '@tauri-apps/cli-win32-ia32-msvc': 2.5.0
       '@tauri-apps/cli-win32-x64-msvc': 2.5.0
+
+  '@tauri-apps/plugin-log@2.6.0':
+    dependencies:
+      '@tauri-apps/api': 2.7.0
 
   '@tauri-apps/plugin-opener@2.2.7':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,11 +18,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-decorum = "1.1.1"
 tokio = { version = "1.47.1", features = ["full"] }
+log = "0.4.27"
+tauri-plugin-log = "2"
 
 

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSCameraUsageDescription</key>
+  <string>Request camera access for WebRTC</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Request microphone access for WebRTC</string>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,9 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "opener:default",
@@ -15,6 +17,7 @@
     "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
-    "decorum:allow-show-snap-overlay"
+    "decorum:allow-show-snap-overlay",
+    "log:default"
   ]
 }

--- a/src-tauri/src/command_detect_devices.rs
+++ b/src-tauri/src/command_detect_devices.rs
@@ -1,18 +1,23 @@
 use std::time::Duration;
 use tokio::net::TcpStream;
 
-use tokio::sync::Semaphore;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 #[tauri::command]
 pub async fn fetch_devices(addresses: Vec<String>) -> Vec<String> {
     // First, check if the device is online by trying to connect to port 9012
-    let semaphore = Arc::new(Semaphore::new(256 * 256));
+    let semaphore = if cfg!(target_os = "macos") {
+        Arc::new(Semaphore::new(256 * 8))
+    } else {
+        Arc::new(Semaphore::new(256 * 256))
+    };
+
     let mut port_check_tasks = Vec::new();
-    
+
     for address in addresses {
         let permit = semaphore.clone().acquire_owned().await.unwrap();
-        
+
         port_check_tasks.push(tokio::spawn(async move {
             let _permit = permit;
             let is_online = check_port(&address, 9012).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use tauri_plugin_decorum::WebviewWindowExt; // adds helper methods to WebviewWin
 // #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_decorum::init())
         .setup(|app| {

--- a/src/stores/device.ts
+++ b/src/stores/device.ts
@@ -65,6 +65,8 @@ export const useDeviceStore = defineStore("devices", () => {
         addresses,
       });
 
+      console.log("Detected devices:", results);
+
       await fetchDevices(results);
     } catch (err) {
     } finally {


### PR DESCRIPTION
… under macos

1. The maximum number of simultaneously open sockets allowed by Apple is limited. 
2. Apple does not allow access to ports using the http protocol and enforces the use of https.

So I modified the maximum number of concurrent operations under macOS. This makes a scan of the 100.100.*.* level take about 60 seconds under macOS, while it originally took less than 2 seconds.  I disabled Apple's ATS (App Transport Security) restriction on HTTP. This will cause the inability to release the iOS version.